### PR TITLE
fix: try to solve the issue that css file not found in ssr mode

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -10,30 +10,33 @@ import { StyleProvider, createCache } from "@ant-design/cssinjs";
 export default class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
     const cache = createCache();
-    let fileName = "";
     const originalRenderPage = ctx.renderPage;
+    let isReady: boolean = false;
     ctx.renderPage = () =>
       originalRenderPage({
-        enhanceApp: (App) => (props) =>
-          (
+        enhanceApp: (App) => (props) => {
+          isReady = !!props.__N_SSP;
+          return (
             <StyleProvider cache={cache}>
               <App {...props} />
             </StyleProvider>
-          ),
+          );
+        },
       });
 
     const initialProps = await Document.getInitialProps(ctx);
     // 1.1 extract style which had been used
-    fileName = doExtraStyle({
+    const { url, fallback } = doExtraStyle({
       cache,
     });
+
     return {
       ...initialProps,
       styles: (
         <>
           {initialProps.styles}
           {/* 1.2 inject css */}
-          {fileName && <link rel="stylesheet" href={`/${fileName}`} />}
+          {url && <link rel="stylesheet" href={isReady ? `/${fallback}` : `/${url}`} />}
         </>
       ),
     };

--- a/pages/api/loadCss.ts
+++ b/pages/api/loadCss.ts
@@ -1,0 +1,41 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import type { NextApiRequest, NextApiResponse } from 'next'
+import path from 'path';
+import fs from 'fs';
+
+const dir = "antd-output";
+const baseDir = path.resolve(__dirname, "../../../static/css");
+
+const outputCssPath = path.join(baseDir, dir);
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { fileName, etag } = req.query;
+
+  if (!fileName) {
+    res.status(400).end();
+    return;
+  }
+  const filePath = path.join(outputCssPath, fileName as string);
+  if (!fs.existsSync(filePath)) {
+    res.status(404).end(); // 返回 404 Not Found
+  }
+
+  
+  const ifNoneMatch = req.headers['if-none-match'];
+  if (ifNoneMatch === etag) {
+    res.status(304).end(); // 返回 304 Not Modified
+    return;
+  }
+
+  const content = fs.readFileSync(filePath, 'utf8');
+  res.setHeader('Content-Type', 'text/css');
+
+  // 设置响应头
+  res.setHeader('Cache-Control', 'public, max-age=31536000, immutable'); // 缓存时间为 1 小时
+  res.setHeader('ETag', etag as string);
+
+  res.end(content);
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,7 +10,6 @@ import {
   Typography,
   Space,
   Divider,
-  Card,
 } from "antd";
 
 const { Option } = Select;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,7 @@ import {
   Typography,
   Space,
   Divider,
+  Card,
 } from "antd";
 
 const { Option } = Select;

--- a/scripts/genAntdCss.tsx
+++ b/scripts/genAntdCss.tsx
@@ -23,7 +23,10 @@ export function doExtraStyle({
   }
 
   const css = extractStyle(cache, true);
-  if (!css) return "";
+  if (!css) return {
+    url: "",
+    fallback: "",
+  };
 
   const md5 = createHash("md5");
   const hash = md5.update(css).digest("hex");
@@ -31,10 +34,17 @@ export function doExtraStyle({
   const fullpath = path.join(outputCssPath, fileName);
 
   const res = `_next/static/css/${dir}/${fileName}`;
+  const resFallback = `api/loadCss?fileName=${fileName}&etag=${hash}`;
 
-  if (fs.existsSync(fullpath)) return res;
+  if (fs.existsSync(fullpath)) return {
+    url: res,
+    fallback: resFallback,
+  };
 
   fs.writeFileSync(fullpath, css);
 
-  return res;
+  return {
+    url: res,
+    fallback: resFallback,
+  };
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -43,8 +43,8 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
+    --background-start-rgb: 80, 80, 80;
+    --background-end-rgb: 80, 80, 80;
 
     --primary-glow: radial-gradient(rgba(1, 65, 255, 0.4), rgba(1, 65, 255, 0));
     --secondary-glow: linear-gradient(
@@ -95,7 +95,8 @@ body {
     rgb(var(--background-start-rgb));
 }
 
-label, h1, h2, .ant-form-text {
+
+label, h1, h2, .ant-form-text, .ant-divider-inner-text, a {
   color: rgb(var(--foreground-rgb)) !important;
 }
 


### PR DESCRIPTION
背景：
我们之前的方案是在 SSR 和 SSG 时根据当前访问页面使用到的组件按需抽取样式并输出到导出目录，从而可以利用浏览器的缓存机制更好的加载组件样式。
这种方式在 SSG 模式看上去是没有问题的，因为 SSG 模式会在运行 build 命令时就会生成样式文件，当我们运行 start 命令时，这些文件就会被加入到 nextjs 的静态文件服务中管理。
但是，SSR 模式 并不会在 build 阶段抽取生成样式，而是在用户第一次访问页面时才会抽取生成，此时 nextjs 的静态文件服务并不会将新生成的样式文件自动纳入管理，因此导致了如下问题：#11。
为了解决这个问题，这边尝试利用 nextjs 的 api ，实现一个接口，通过传入目标样式名称给 loadCss 接口，让接口查找目标样式文件并输出。
为了尽可能利用浏览器的缓存机制，我们需要在 loadCss 接口当中设置一定的缓存策略，让浏览器接受到接口响应后按要求缓存内容。
**此方案目前处于实验阶段，具体是否可行还需讨论。**
![image](https://github.com/ant-design/create-next-app-antd/assets/10286961/29f69f37-2428-4d14-8e9b-6bbe66e029cd)
![image](https://github.com/ant-design/create-next-app-antd/assets/10286961/ae927840-3053-456a-a3e9-75c99c0698a3)
